### PR TITLE
Make compatible with Inkspace 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# Inkscape Extension BetterBetterDXFOutput (b2_dxf) 2021
-DXF Exporter for Inkscape (Better Better DXF Output Version2021)
+# Inkscape Extension Better Better DXF Output 2023
 
-Updated version of BetterBetterDXFOutput for recent Inkscape versions. Tested with [Inkscape](https://inkscape.org) version 1.1
+DXF Exporter for Inkscape 
+
+Updated version of BetterBetterDXFOutput for Inkscape 1.2
+
+changes of this fork:
+* fix for Inkscape 1.2
+* export in layer 0
+* calculate correct scaling fpr output in mm
 
 ## Installation ##
 

--- a/b2r_dxf_outlines.inx
+++ b/b2r_dxf_outlines.inx
@@ -1,5 +1,5 @@
 <inkscape-extension>
-    <_name>Better Better DXF Output 2021/Inkscape 1.1</_name>
+    <_name>Better Better DXF Output 2023/Inkscape 1.2</_name>
     <id>org.ekips.output.b2_dxf_outlines</id>
         <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
         <dependency type="executable" location="extensions">b2_dxf_outlines.py</dependency>
@@ -8,8 +8,8 @@
     <output>
                 <extension>.dxf</extension>
                 <mimetype>image/dxf</mimetype>
-                <_filetypename>Better Better DXF Output 2021 (*.DXF)</_filetypename>
-                <_filetypetooltip>Better Better DXF Output 2021</_filetypetooltip>
+                <_filetypename>Better Better DXF Output 2023 (*.DXF)</_filetypename>
+                <_filetypetooltip>Better Better DXF Output 2023</_filetypetooltip>
                 <dataloss>TRUE</dataloss>
     </output>
     <script>

--- a/b2r_dxf_outlines.inx
+++ b/b2r_dxf_outlines.inx
@@ -3,7 +3,6 @@
     <id>org.ekips.output.b2_dxf_outlines</id>
         <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
         <dependency type="executable" location="extensions">b2_dxf_outlines.py</dependency>
-        <dependency type="executable" location="extensions">inkex.py</dependency>
         <dependency type="executable" location="extensions">simpletransform.py</dependency>
         <dependency type="executable" location="extensions">dxf_templates_b2.py</dependency>
     <output>


### PR DESCRIPTION
remove dep to inkex.py, which is deprecated since inkscape 1.0, fails with 1.2